### PR TITLE
Added two version of datomic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u151-jdk
 MAINTAINER Alexander Kiel <alexanderkiel@gmx.net>
 
-ENV DATOMIC_VERSION 0.9.5697
+ENV DATOMIC_VERSION 0.9.5703
 
 ADD https://my.datomic.com/downloads/free/${DATOMIC_VERSION} /tmp/datomic.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u151-jdk
 MAINTAINER Alexander Kiel <alexanderkiel@gmx.net>
 
-ENV DATOMIC_VERSION 0.9.5656
+ENV DATOMIC_VERSION 0.9.5697
 
 ADD https://my.datomic.com/downloads/free/${DATOMIC_VERSION} /tmp/datomic.zip
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ described in [Managing Data in Containers][4].
 To run a specific version of Datomic, you can use tags. The following images are
 available:
 
+* akiel/datomic-free:0.9.5697
 * akiel/datomic-free:0.9.5656
 * akiel/datomic-free:0.9.5651
 * akiel/datomic-free:0.9.5561.62

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ described in [Managing Data in Containers][4].
 To run a specific version of Datomic, you can use tags. The following images are
 available:
 
+* akiel/datomic-free:0.9.5703
 * akiel/datomic-free:0.9.5697
 * akiel/datomic-free:0.9.5656
 * akiel/datomic-free:0.9.5651


### PR DESCRIPTION
Added the two latest versions of [datomic-free](https://my.datomic.com/downloads/free): `0.9.5697` and  `0.9.5703`.  I have verified the download url manually.

I believe you will need to push the docker containers manually.  I do not have the permission.