### PR TITLE
Fix: enable remote access due new security changes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN cp config/samples/free-transactor-template.properties transactor.properties
 
 RUN sed "s/host=localhost/host=0.0.0.0/" -i transactor.properties
 
+RUN sed "s/# storage-access=local/storage-access=remote/" -i transactor.properties
+
 RUN mkdir /data
 RUN sed "s/# data-dir=data/data-dir=\/data/" -i transactor.properties
 VOLUME /data

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ is sufficient
 
 You can access your databases through this URIs
 
-    datomic:free://localhost:4334/<DB_NAME>
+    datomic:free://localhost:4334/<DB_NAME>?password=my-pwd
 
 If your Docker host differs from localhost, you have to specify the hostname or
 IP through the environment variable ALT_HOST
@@ -28,7 +28,25 @@ IP through the environment variable ALT_HOST
 
 and access your databases through the URIs
 
-    datomic:free://<DOCKER_HOST>:4334/<DB_NAME>
+    datomic:free://<DOCKER_HOST>:4334/<DB_NAME>?password=my-pwd
+
+If you want to specify the database password you can do it through the environment
+variable DB_PASSWORD
+
+    docker run -d -p 4334-4336:4334-4336 -e DB_PASSWORD=<YOUR_PWD> --name datomic-free akiel/datomic-free
+
+and access your databases through this URIs
+
+    datomic:free://localhost:4334/<DB_NAME>?password=<YOUR_PWD>
+
+To change the database password you can do it through the environment
+variables DB_PASSWORD and DB_OLD_PASSWORD
+
+    docker run -d -p 4334-4336:4334-4336 -e DB_OLD_PASSWORD=<YOUR_PWD> -e DB_PASSWORD=<YOUR_NEW_PWD> --name datomic-free akiel/datomic-free
+
+and access your databases through this URIs
+
+    datomic:free://localhost:4334/<DB_NAME>?password=<YOUR_NEW_PWD>
 
 The image exposes two volumes, one `/data` and one `/log` volume. If you give
 your containers names like in the commands above, you don't have to bind 

--- a/start.sh
+++ b/start.sh
@@ -2,4 +2,13 @@
 
 sed "/host=0.0.0.0/a alt-host=${ALT_HOST:-127.0.0.1}" -i transactor.properties
 
+sed "s/# storage-admin-password=/storage-admin-password=${DB_PASSWORD:-my-pwd}/" -i transactor.properties
+sed "s/# storage-datomic-password=/storage-datomic-password=${DB_PASSWORD:-my-pwd}/" -i transactor.properties
+
+if [ -n "$DB_OLD_PASSWORD" ]
+then
+  sed "s/# old-storage-admin-password=/old-storage-admin-password=$DB_OLD_PASSWORD/" -i transactor.properties
+  sed "s/# old-storage-datomic-password=/old-storage-datomic-password=$DB_OLD_PASSWORD/" -i transactor.properties
+fi
+
 bin/transactor transactor.properties


### PR DESCRIPTION
The release 0.9.5697 makes some security changes that enforces you
to open the JDBC server to external connections.
For this you must explicitly enable it via a property setting and also
set passwords for the ‘admin’ and ‘datomic’ users.

Fix Github issue #5