### PR TITLE
Allow secrets to be conveyed via files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-MAINTAINER Alexander Kiel <alexanderkiel@gmx.net>
 FROM openjdk:8u275-jre
+LABEL maintainer="Chris Hapgood cch1@hapgood.com"
 
 ENV DATOMIC_VERSION 0.9.5703.21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:8u242-jre
 MAINTAINER Alexander Kiel <alexanderkiel@gmx.net>
+FROM openjdk:8u275-jre
 
 ENV DATOMIC_VERSION 0.9.5703.21
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,8 @@ RUN sed "s/# log-dir=log/log-dir=\/log/" -i transactor.properties
 
 ADD start.sh ./
 RUN chmod +x start.sh
+ADD read-secrets.sh ./
+RUN chmod +x read-secrets.sh
 
 EXPOSE 4334 4335 4336
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:8u242-jre
 MAINTAINER Alexander Kiel <alexanderkiel@gmx.net>
 
-ENV DATOMIC_VERSION 0.9.5703
+ENV DATOMIC_VERSION 0.9.5703.21
 
 RUN wget https://my.datomic.com/downloads/free/${DATOMIC_VERSION} -qO /tmp/datomic.zip \
   && unzip /tmp/datomic.zip \

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: all push
+
+SHELL = /bin/bash
+VERSION ?= latest
+
+all: build
+
+build: Dockerfile start.sh read-secrets.sh
+	docker build --tag cch1/datomic-free:$(VERSION) .
+
+push:
+	docker push cch1/datomic-free:$(VERSION)

--- a/read-secrets.sh
+++ b/read-secrets.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+env_secret_debug()
+{
+    if [ ! -z "$ENV_SECRETS_DEBUG" ]; then
+        echo -e "\033[1m$@\033[0m"
+    fi
+}
+
+read-secret()
+{
+    var_name="$1"
+    var_fname="${var_name}_FILE"
+    eval fname=\$$var_fname
+    if [ -n "$fname" ]; then
+	env_secret_debug "Found env var $var_fname = $fname"
+	if [ -f $fname ]; then
+	    val=$(cat "${fname}")
+	    export "$var_name"="$val"
+	    env_secret_debug "Slurped value $val into var $var_name from $fname"
+	else
+	    env_secret_debug "ERROR: file $fname not found"
+	fi
+    else
+	env_secret_debug "File var $var_fname not present"
+    fi
+}
+
+read-secrets()
+{
+    for var_name in "$@" ; do
+	read-secret $var_name
+    done
+    env_secret_debug "Read secrets $@"
+}
+
+read-secrets $@

--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+source ./read-secrets.sh DATOMIC_PASSWORD DATOMIC_PASSWORD_OLD ADMIN_PASSWORD ADMIN_PASSWORD_OLD
+
 if [ -z "$ADMIN_PASSWORD" ]; then
   echo "Environment variable ADMIN_PASSWORD not set. See https://docs.datomic.com/on-prem/configuring-embedded.html#sec-2-1"
   exit 1


### PR DESCRIPTION
Files are preferable to env vars for conveying sensitive data into the container.  This PR uses the convention that if env var `X_FILE` is present and it references a file then env var `X` is set to its contents.  The scope of env vars considered by this PR is limited to sensitive data used by Datomic Free.